### PR TITLE
VRVU-389: Once again, fix for query that counts active and voided pat…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.openmrs.module</groupId>
     <artifactId>vxnaidbiometric</artifactId>
-    <version>1.3.0-vrvu.7</version>
+    <version>1.3.0-vrvu.8</version>
   </parent>
 
   <artifactId>vxnaidbiometric-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/biometric/api/db/impl/SyncDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/biometric/api/db/impl/SyncDaoImpl.java
@@ -14,12 +14,15 @@ import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
+import org.hibernate.criterion.Subqueries;
 import org.hibernate.sql.JoinType;
 import org.hibernate.transform.Transformers;
 import org.openmrs.Patient;
+import org.openmrs.PersonAttribute;
 import org.openmrs.Visit;
 import org.openmrs.module.biometric.api.db.SyncDao;
 import org.openmrs.module.biometric.api.helper.SyncQueryHelper;
@@ -209,12 +212,20 @@ public class SyncDaoImpl implements SyncDao {
   }
 
   private Criteria buildPatientLocationsCriteria(List<String> locations) {
-    final Criteria criteria = sessionFactory.getCurrentSession().createCriteria(Patient.class);
+    final Criteria criteria = sessionFactory.getCurrentSession().createCriteria(Patient.class, "p");
+
     criteria.createAlias("attributes", "attribute", JoinType.INNER_JOIN);
     criteria.createAlias("attribute.attributeType", "attributeType", JoinType.INNER_JOIN);
-    criteria.add(Restrictions.eq("attribute.voided", Boolean.FALSE));
+
+    DetachedCriteria maxDateSubquery = DetachedCriteria.forClass(PersonAttribute.class, "subAttr")
+        .createAlias("attributeType", "subType")
+        .add(Restrictions.eq("subType.name", "LocationAttribute"))
+        .add(Restrictions.eqProperty("subAttr.person.personId", "p.patientId"))
+        .setProjection(Projections.max("subAttr.dateCreated"));
+
     criteria.add(Restrictions.eq("attributeType.name", "LocationAttribute"));
     criteria.add(Restrictions.in("attribute.value", locations));
+    criteria.add(Subqueries.propertyEq("attribute.dateCreated", maxDateSubquery));
     return criteria;
   }
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>vxnaidbiometric</artifactId>
-        <version>1.3.0-vrvu.7</version>
+        <version>1.3.0-vrvu.8</version>
     </parent>
 
     <artifactId>vxnaidbiometric-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.openmrs.module</groupId>
   <artifactId>vxnaidbiometric</artifactId>
-  <version>1.3.0-vrvu.7</version>
+  <version>1.3.0-vrvu.8</version>
   <packaging>pom</packaging>
   <name>Biometric API Module</name>
   <description>The biometric module will provide REST APIs to integrate biometric solutions


### PR DESCRIPTION
Should return results inline with:
```
select p.voided, count(*)
from patient p
inner join person r on r.person_id = p.patient_id
where (
		select pa.value 
		from person_attribute pa 
		inner join person_attribute_type pat on pat.person_attribute_type_id = pa.person_attribute_type_id 
		where pat.name = 'LocationAttribute' and pa.person_id = p.patient_id
        order by pa.date_created desc
        limit 1
	) in (:locations)
group by p.voided;
```